### PR TITLE
T242459: Fix initialization parameter for superclass in PerfactUserwarning 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+22.2.0
+======
+
+- Fix parameter in ``PerFactUserWarning`` so these are not included in the
+  error log.
+
+- Adjust version numbering
+
 0.8
 ===
 

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -131,4 +131,4 @@ class PerFactUserWarning(PerFactException):
     def __init__(self, msg='', payload=None, **kw):
         super(PerFactUserWarning, self).__init__(
             msg=msg, show_to_user=True,
-            appuserlog=False, payload=payload, **kw)
+            apperrorlog=False, payload=payload, **kw)

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -129,10 +129,6 @@ class PerFactUserWarning(PerFactException):
     '''
 
     def __init__(self, msg='', payload=None, **kw):
-
-        if 'apperrorlog' in kw:
-            del kw['apperrorlog']
-
         super(PerFactUserWarning, self).__init__(
             msg=msg, show_to_user=True,
             apperrorlog=False, payload=payload, **kw)

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -129,6 +129,10 @@ class PerFactUserWarning(PerFactException):
     '''
 
     def __init__(self, msg='', payload=None, **kw):
+
+        if 'apperrorlog' in kw:
+            del kw['apperrorlog']
+
         super(PerFactUserWarning, self).__init__(
             msg=msg, show_to_user=True,
             apperrorlog=False, payload=payload, **kw)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.8'
+version = '22.2.0'
 
 setup(name='Products.PerFactErrors',
       version=version,


### PR DESCRIPTION
@viktordick As we talked about earlier, I prepared a small PR for this finding. 

However the actual behavior on apperrorlog parameter does not change, because PerFactException initializes it defaultly as False anyway. 

I also removed apperrorlog as possible key word argument to prevent taking it twice as parameter.
What do you think? Will we change the intended/lived behavior by this?