### PR TITLE
T260128: Optimize PerFactException handling for charmeleon PTs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+22.3.0
+======
+
+- Fix ``PerFactException`` handling for charmeleon-based page templates.
+
+- Adjust version numbering
+
 22.2.0
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 22.3.0
 ======
 
-- Fix ``PerFactException`` handling for charmeleon-based page templates.
+- Fix ``PerFactException`` handling for Chameleon-based page templates.
 
 - Adjust version numbering
 

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -56,9 +56,11 @@ def afterfail_error_message(event):
         # the error value by its original string representation. Information
         # like the exact line and expression in the page template can still be
         # found in the event.log and in the traceback.
-        if hasattr(error_value, '_original__str__')  and not isinstance(error_value, PerFactException):
+        if (
+            hasattr(error_value, '_original__str__')
+            and not isinstance(error_value, PerFactException)
+        ):
             error_value = error_value._original__str__()
-            logger.exception()
 
 
         # Chameleon's own errors are also too verbose

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -62,7 +62,6 @@ def afterfail_error_message(event):
         ):
             error_value = error_value._original__str__()
 
-
         # Chameleon's own errors are also too verbose
         if isinstance(error_value, PTRuntimeError):
             error_value = 'Error parsing page template'

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -56,8 +56,10 @@ def afterfail_error_message(event):
         # the error value by its original string representation. Information
         # like the exact line and expression in the page template can still be
         # found in the event.log and in the traceback.
-        if hasattr(error_value, '_original__str__'):
+        if hasattr(error_value, '_original__str__')  and not isinstance(error_value, PerFactException):
             error_value = error_value._original__str__()
+            logger.exception()
+
 
         # Chameleon's own errors are also too verbose
         if isinstance(error_value, PTRuntimeError):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '22.2.0'
+version = '22.3.0'
 
 setup(name='Products.PerFactErrors',
       version=version,


### PR DESCRIPTION
Errors rendered in charmeleon based page templates were returned as concatenated string to prevent displaying to much information.
However in case of PerFactExceptions, it reduced the potential rendering Errors properly.

With this we restore this very potential. 