### PR TITLE
T264586: Add rendering for explicit exception causes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+23.1.0
+======
+
+- Also render exception causes according to 
+  [PEP 3134](https://peps.python.org/pep-3134/#explicit-exception-chaining)
+
 23.0.0
 ======
 

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -44,12 +44,31 @@ def afterfail_error_message(event):
         if log_error:
             logger.exception(error_value)
 
-        error_tb = '\n'.join(
+        tracebacks = []
+        tracebacks.append('\n'.join(
             zExceptions.ExceptionFormatter.format_exception(
                 error_type, error_value, error_tb,
                 as_html=True,
             )
-        )
+        ))
+
+        cause = error_value.__cause__
+        while cause:
+            tracebacks.append('\n'.join(
+                zExceptions.ExceptionFormatter.format_exception(
+                    type(cause),
+                    cause,
+                    cause.__traceback__,
+                    as_html=True,
+                )
+            ))
+            cause = cause.__cause__
+
+        tracebacks.reverse()
+        error_tb = (
+            'The above exception was the '
+            'direct cause of the following exception:\n'
+        ).join(tracebacks)
 
         # Chameleon adds some traceback information to the error_value's
         # __str__ method, which we do not want to show the user, so we replace

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '23.0.0'
+version = '23.1.0'
 
 setup(name='Products.PerFactErrors',
       version=version,


### PR DESCRIPTION
The current implementation of `zExceptions.ExceptionFormatter` does not allow rendering of full stacks for exceptions with explicit cause exceptions (raise Exception from ..) (see https://github.com/zopefoundation/zExceptions/issues/14) 
This PR implements a workaround by going up the cause chain of the exception and using the formatter for each seperate exception. The result may look something like this:

![grafik](https://github.com/user-attachments/assets/43aa96b4-1ccc-4bb2-84a9-050430e1e016)
