### PR TITLE
T288139: Log PerFactExceptions to apperrorlog on default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+23.2.0
+======
+
+- Modify the ``PerFactException`` parameter apperrorlog's default behavior.
+  If not specifically deactivated, the exception will then trigger logging 
+  into the related error log.
+
 23.1.0
 ======
 

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -110,7 +110,7 @@ class PerFactException(Exception):
     '''
 
     def __init__(self, msg='', show_to_user=False,
-                 apperrorlog=False, payload=None, **kw):
+                 apperrorlog=True, payload=None, **kw):
         '''
         Input:
         - "msg" (string) is the error message,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '23.1.0'
+version = '23.2.0'
 
 setup(name='Products.PerFactErrors',
       version=version,


### PR DESCRIPTION
Some people (me included) assume that this exception class is logging automatically into the error log, if raised without any explicit flags. However it is currently necessary to explicitly set this flag everytime to True, which is quite often. 

Therefore I would like to flip the behavior here.