### PR TITLE
T293543: Add readonly property 'status_code' to 'PerFactException'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+23.4.0
+======
+
+- Add readonly property ``status_code`` to ``PerFactException`` classes.
+  This will be set only within constructer (for now) and can be used within
+  exception handling to define the actual returning status code.
+
 23.3.0
 ======
 

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -140,9 +140,14 @@ class PerFactException(Exception):
         self.show_to_user = show_to_user
         self.apperrorlog = apperrorlog
         self.payload = payload or {}
+        self.__status_code__ = 500
 
     def __str__(self):
         return repr((self.msg, self.payload))
+
+    @property
+    def status_code(self):
+        return self.__status_code__
 
 
 class PerFactUserWarning(PerFactException):
@@ -157,3 +162,4 @@ class PerFactUserWarning(PerFactException):
         super(PerFactUserWarning, self).__init__(
             msg=msg, show_to_user=True,
             apperrorlog=False, payload=payload, **kw)
+        self.__status_code__ = 422  # Unprocessable Entity

--- a/Products/PerFactErrors/errors.py
+++ b/Products/PerFactErrors/errors.py
@@ -140,14 +140,14 @@ class PerFactException(Exception):
         self.show_to_user = show_to_user
         self.apperrorlog = apperrorlog
         self.payload = payload or {}
-        self.__status_code__ = 500
+        self._status_code = 500
 
     def __str__(self):
         return repr((self.msg, self.payload))
 
     @property
     def status_code(self):
-        return self.__status_code__
+        return self._status_code
 
 
 class PerFactUserWarning(PerFactException):
@@ -162,4 +162,4 @@ class PerFactUserWarning(PerFactException):
         super(PerFactUserWarning, self).__init__(
             msg=msg, show_to_user=True,
             apperrorlog=False, payload=payload, **kw)
-        self.__status_code__ = 422  # Unprocessable Entity
+        self._status_code = 422  # Unprocessable Entity

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '23.2.0'
+version = '23.4.0'
 
 setup(name='Products.PerFactErrors',
       version=version,


### PR DESCRIPTION
  This will be set only within constructer (for now) and can be used within exception handling to define the actual returning status code.

- PerFactException.status_code → 500 
- PerFactUserWarning.status_code → 422 (Unprocessable Entity)